### PR TITLE
remove min section

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,18 +239,7 @@ family_members.keys
 #  => [:mom, :dad, :sister]
 ```
 
-### `.min`
-
-You can use the `.min` method on a hash to return the key/value *pair* that contains that **lowest** value: 
-
-```ruby
-food_items = {apples: 45, pears: 12}
-
-food_items.min
-#  => [:apples, 45] 
-```
-
-These are only a few of the many helpful methods out there. Be sure to check out the [Ruby Docs on Hashes](http://ruby-doc.org/core-2.2.2/Hash.html) to learn more. 
+There are many other useful methods for hashes. Be sure to check out the [Ruby Docs on Hashes](http://ruby-doc.org/core-2.2.2/Hash.html) to learn more. 
 
 Let's practice before you move on to the next challenge: 
 


### PR DESCRIPTION
fixes #17 - the .min example here felt out of place here - the solution to the lab doesn't use it at all. 

If we want to keep the `.min` example here, it should read something as follows. 

You can use the .min method on a hash to return the key/value pair that contains that lowest key, either alphabetically or numerically. For example:

```
food_items = {apples: 45, pears: 12}

food_items.min
#  => [:apples, 45] 
```
